### PR TITLE
Refactored validation within GeneralCommands and various warnings

### DIFF
--- a/DiscordBot.App/Middlewares/BasicAuthenticationHandler.cs
+++ b/DiscordBot.App/Middlewares/BasicAuthenticationHandler.cs
@@ -26,7 +26,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        string authHeader = Request.Headers["Authorization"];
+        string? authHeader = Request.Headers["Authorization"];
         if (authHeader != null && authHeader.StartsWith("Basic"))
         {
 
@@ -43,9 +43,9 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
                 var principal = new ClaimsPrincipal(identity);
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
-                return AuthenticateResult.Success(ticket);
+                return await Task.FromResult(AuthenticateResult.Success(ticket));
             }
         }
-        return AuthenticateResult.Fail("Failed to authenticate");
+        return await Task.FromResult(AuthenticateResult.Fail("Failed to authenticate"));
     }
 }

--- a/DiscordBot.App/Program.cs
+++ b/DiscordBot.App/Program.cs
@@ -28,7 +28,7 @@ builder.Services.AddSingleton<DiscordService>();
 builder.Services.AddSingleton<LoginService>();
 builder.Services.AddSingleton<RunnerService>();
 builder.Services.AddSingleton<GuildJoinService>();
-builder.Services.AddHostedService(provider => provider.GetService<RunnerService>());
+builder.Services.AddHostedService(provider => provider.GetRequiredService<RunnerService>());
 
 builder.Services.AddAuthentication("BasicAuthentication")
         .AddScheme<AuthenticationSchemeOptions, BasicAuthenticationHandler>("BasicAuthentication", null);
@@ -44,7 +44,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-await app.Services.GetService<DiscordService>().Start();
+await app.Services.GetRequiredService<DiscordService>().Start();
 
 app.UseHttpsRedirection();
 app.UseAuthentication();
@@ -52,7 +52,7 @@ app.UseAuthorization();
 
 app.Use(async (context, next) =>
 {
-    if (!context.Connection.RemoteIpAddress.Equals(context.Connection.LocalIpAddress))
+    if (context.Connection.RemoteIpAddress == null || !context.Connection.RemoteIpAddress.Equals(context.Connection.LocalIpAddress))
     {
         context.Response.StatusCode = 403;
         return;

--- a/DiscordBot.App/Services/DiscordService.cs
+++ b/DiscordBot.App/Services/DiscordService.cs
@@ -10,6 +10,7 @@ using DSharpPlus.SlashCommands;
 
 namespace DiscordBot.Services;
 
+#nullable disable
 public class DiscordService
 {
     public DiscordClient Client { get; private set; }

--- a/DiscordBot.App/Settings/DiscordSettings.cs
+++ b/DiscordBot.App/Settings/DiscordSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace DiscordBot.Settings;
 
+#nullable disable
 public class Roles
 {
     public ulong Member { get; set; }

--- a/DiscordBot.App/Settings/ServerApiSettings.cs
+++ b/DiscordBot.App/Settings/ServerApiSettings.cs
@@ -1,5 +1,5 @@
 ﻿namespace DiscordBot.Settings;
-
+#nullable disable
 public class ServerApiSettings
 {
     public string Url { get; set; }

--- a/DiscordBot.Data/Models/Credentials.cs
+++ b/DiscordBot.Data/Models/Credentials.cs
@@ -1,5 +1,5 @@
 ﻿namespace DiscordBot.Models;
-
+#nullable disable
 public class Credentials
 {
     public string Username { get; set; }

--- a/DiscordBot.Data/Models/DiscordUserDto.cs
+++ b/DiscordBot.Data/Models/DiscordUserDto.cs
@@ -1,5 +1,5 @@
 ﻿namespace DiscordBot.Models;
-
+#nullable disable
 public class DiscordUserDto
 {
     public string Id { get; set; }

--- a/DiscordBot.Data/Models/ResponsePairDto.cs
+++ b/DiscordBot.Data/Models/ResponsePairDto.cs
@@ -1,5 +1,5 @@
 ﻿namespace DiscordBot.Models;
-
+#nullable disable
 public class ResponsePairDto
 {
     public ResponsePairDto()

--- a/DiscordBot.FakeServer/Middlewares/BasicAuthenticationHandler.cs
+++ b/DiscordBot.FakeServer/Middlewares/BasicAuthenticationHandler.cs
@@ -26,7 +26,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        string authHeader = Request.Headers["Authorization"];
+        string? authHeader = Request.Headers["Authorization"];
         if (authHeader != null && authHeader.StartsWith("Basic", StringComparison.InvariantCultureIgnoreCase))
         {
 
@@ -43,9 +43,9 @@ public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSc
                 var principal = new ClaimsPrincipal(identity);
                 var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
-                return AuthenticateResult.Success(ticket);
+                return await Task.FromResult(AuthenticateResult.Success(ticket));
             }
         }
-        return AuthenticateResult.Fail("Failed to authenticate");
+        return await Task.FromResult(AuthenticateResult.Fail("Failed to authenticate"));
     }
 }


### PR DESCRIPTION
PR contains improvements to code base and its readability:

- Validation code wtihin GeneralCommands has been refactored to cut down on alot of repetitive checks that have been pulled out into a seperate function
- Tackled two instances of an async method acting synchornous by default, Task.FromResult was used to keep same sync/async flow but to show intentions more clearly.
- Disabled nullable references in various ORM classes where it made sense to do which also removed nullable warnings. There may be scope in the future to consider logic to explicitly tackle them but disabling makes more sense with their current use.
- Small code changes that also tackle nullable warnings where it made sense to do so.

Only a single warning should be left in the solution. 